### PR TITLE
fix: Reverse maxBatch default value typo to allow override

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ function createIndex (ldb, opts, makeFn) {
   var dataDb = sub(ldb, 'd', opts)
 
   var basic = {
-    maxBatch: 100 || opts.maxBatch,
+    maxBatch: opts.maxBatch || 100,
 
     storeState: function (state, cb) {
       state = state.toString('base64')

--- a/test/test.js
+++ b/test/test.js
@@ -4,6 +4,17 @@ var ram = require('random-access-memory')
 var memdb = require('memdb')
 var test = require('tape')
 
+test('options', function (t) {
+  t.test('maxBatch default override', function (t) {
+    t.plan(1)
+    var lvl = memdb()
+
+    const maxBatchOption = 1337
+    var view = View(lvl, { maxBatch: maxBatchOption }, function (db) {})
+    t.same(view.maxBatch, maxBatchOption)
+  })
+})
+
 test('mapper', function (t) {
   t.plan(7)
 


### PR DESCRIPTION
Noticed that the `maxBatch` option wasn't being overridden in the view constructor. Looks like a typo which causes the default `100` to just always be the value.